### PR TITLE
feat: add hypertrons configuration

### DIFF
--- a/.github/hypertrons.json
+++ b/.github/hypertrons.json
@@ -1,0 +1,42 @@
+{
+    "label_setup": {
+        "version": 1,
+        "labels": []
+    },
+    "weekly_report": {
+        "version": 1,
+        "generateTime": "0 0 12 * * 1"
+    },
+    "role": {
+        "version": 1,
+        "roles": [
+            {
+                "name": "replier",
+                "description": "Replier is responsible for reply issues in time",
+                "users": [
+                    "xiaoya-Esther",
+                    "sunshinemingo",
+                    "limj0825"
+                ],
+                "commands": []
+            },
+            {
+                "name": "anyone",
+                "description": "Anyone",
+                "users": [],
+                "commands": [
+                    "/self-assign"
+                ]
+            }
+        ]
+    },
+    "issue_reminder": {
+        "version": 1
+    },
+    "auto_label": {
+        "version": 1
+    },
+    "self_assign": {
+        "version": 1
+    }
+}


### PR DESCRIPTION
启用的功能如下：
- weekly-report： 以 issue 的方式发送周报，可参考[这里](https://github.com/hypertrons/hypertrons/issues/284)
- issue-reminder：issue 提醒功能，如果 issue 超过 24 小时没有人回复，则会自动 @角色为 `replier` 的所有 GitHub 账号，这里配置了3位助教的账号
- auto-label：自动 label 功能，对 issue title 中的关键字进行解析，并自动添加对应的 label，关键字与 label 的关系可参考[这里](https://github.com/hypertrons/hypertrons/blob/master/app/component/label_setup/defaultConfig.ts)，当然，这里提供了默认的，也可以自己配置，可参考[这里](https://github.com/hypertrons/hypertrons/blob/master/.github/hypertrons.json)
- self-assign：issue提出以后，任何人回复 `/self-assign`，表示这个 issue assign 给评论者




Signed-off-by: WuShaoling <wsl6@outlook.com>